### PR TITLE
Empty result issue

### DIFF
--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -52,8 +52,8 @@ def _process_search(
     st.session_state[key]["search"] = searchterm
     search_results = search_function(searchterm)
 
-    if not search_results:
-        return st.session_state[key]["result"]
+    if search_results is None:
+        search_results = []
 
     def _get_label(label: any) -> str:
         return str(label[0]) if isinstance(label, tuple) else str(label)


### PR DESCRIPTION
Solution for #15.

Hey, thanks for the great work!

When the `search function` returns `empty list`, [this line](https://github.com/m-wrzr/streamlit-searchbox/blob/4729c95b592400a5d16771b8f1fc1130c0ab43b4/streamlit_searchbox/__init__.py#L55) returns True, and the `searchbox` returns the last result which is not empty.

## Behavior:
<img src="https://user-images.githubusercontent.com/29026534/232060841-24db56f0-81d6-4d94-a960-70b9705b4cb9.png" width="400" height="250"><img src="https://user-images.githubusercontent.com/29026534/232060956-4b7d86e1-6721-4b3a-afa6-ffd88c3b9bca.png" width="400" height="250">

## Expected:
<img src="https://user-images.githubusercontent.com/29026534/232060841-24db56f0-81d6-4d94-a960-70b9705b4cb9.png" width="400" height="250"><img src="https://user-images.githubusercontent.com/29026534/232062318-e22859c7-8866-489f-9868-c00e779eb11c.png" width="400" height="250">

## Solution:
Make `search function` return value `empty list` if it is `None` and do nothing.