### PR TITLE
Use Creatable select instead.

### DIFF
--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -51,6 +51,7 @@ def _process_search(
 
     st.session_state[key]["search"] = searchterm
     search_results = search_function(searchterm)
+    search_results.append(searchterm)
 
     if search_results is None:
         search_results = []

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -50,8 +50,7 @@ def _process_search(
         return st.session_state[key]["result"]
 
     st.session_state[key]["search"] = searchterm
-    search_results = search_function(searchterm)
-    search_results.append(searchterm)
+    search_results = [searchterm] + search_function(searchterm)
 
     if search_results is None:
         search_results = []

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -4,7 +4,7 @@ import {
   withStreamlitConnection,
 } from "streamlit-component-lib"
 import React, { ReactNode } from "react"
-import Select from "react-select"
+import CreatableSelect from "react-select/creatable"
 
 import SearchboxStyle from "./styling"
 
@@ -97,7 +97,7 @@ class Searchbox extends StreamlitComponentBase<State> {
         {this.props.args.label ? (
           <div style={this.style.label}>{this.props.args.label}</div>
         ) : null}
-        <Select
+        <CreatableSelect
           // dereference on clear
           ref={this.ref}
           isClearable={true}
@@ -118,6 +118,10 @@ class Searchbox extends StreamlitComponentBase<State> {
           onMenuOpen={() => this.setState({ menu: true })}
           onMenuClose={() => this.setState({ menu: false })}
           menuIsOpen={this.props.args.options && this.state.menu}
+          createOptionPosition={"first"}
+          closeMenuOnSelect={false}
+          hideSelectedOptions={false}
+          formatCreateLabel={(inputValue) => inputValue}
         />
       </div>
     )


### PR DESCRIPTION
Fixes #18.

## Changes
- Uses `CreatableSelect` instead of `Select` from `react-select` library to add the `searchterm` value to the options that is displayed as suggestions as the input is type
- It added the modified list of options to the `session_state`

## Testing
Was able to test the fix and get the `searchterm` itself added as one of the options that is submitted to mirror a google search like experience.
**Google search: Shows the search term as the first suggestion**
<img width="341" alt="image" src="https://github.com/m-wrzr/streamlit-searchbox/assets/72515998/08e45f52-56da-43a9-8da2-ef0a371c6a1d">

**My streamlit app shows the `searchterm` itself as a suggestion:**
<img width="537" alt="image" src="https://github.com/m-wrzr/streamlit-searchbox/assets/72515998/3ecd3d34-58f7-429c-98b9-542823bb2ee0">

I used the code in this PR built using `python setup.py sdist bdist_wheel` command and then installing the wheel file into my streamlit app's conda environment.

@m-wrzr Let me know if you like to see any improvement or you're satisfied with the change.
