### PR TITLE
Adding delay method

### DIFF
--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import time
 from typing import Any, Callable, List
 
 import streamlit as st
@@ -103,7 +104,7 @@ def st_searchbox(
     default_options: List[Any] | None = None,
     clear_on_submit: bool = False,
     rerun_on_update: bool = True,
-    key: str = "searchbox",
+    key: str = "searchbox", delay: int = None,
     **kwargs,
 ) -> Any:
     """
@@ -128,6 +129,10 @@ def st_searchbox(
         any: based on user selection
     """
 
+    # delay request (useful if you have a limit of request API)
+    if delay:
+        time.sleep(delay)
+        
     # key without prefix used by react component
     key_react = f"{key}_react"
 


### PR DESCRIPTION
Sometime, servers where we can do requests have limit of requests per second. So adding a delay avoids this problem.

I saw in the package that there is a :param delay. Maybe you're already working on it.

This addition of delay is due to the fact that I use an API where we have an easily reachable limit. Usually 0.25 seconds is enough

