### PR TITLE
Updated README.md to reflect the correct keyword argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ rerun_on_update: bool = True
 Use `st.experimental_rerun()` to reload the app after user input and load new search suggestions. Disabling leads to delay in showing the proper search results.
 
 ```python
-editable_after_submit: bool = False
+edit_after_submit: Literal["disabled", "current", "option", "concat"] = "disabled"
 ```
 
-Do not reset the input after an option is selected but keep it editable
+Specify behavior for search query after an option is selected.
 
 ```python
 style_overrides: dict | None = None


### PR DESCRIPTION
Hi!

I have noticed that the keyword argument `editable_after_submit` does not exist, and instead `edit_after_submit` does, but this is not reflected in README.md. This may confuse new users with regards to the documentation and usage.

Hope this helps. 

Thanks!
