### PR TITLE
remove tests from distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include streamlit_searchbox/frontend/build *
+recursive-exclude tests *

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     + "and provides a list of suggestions based on a provided function",
     long_description_content_type="text/plain",
     url="https://github.com/m-wrzr/streamlit-searchbox",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests",)),
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.8, !=3.9.7",


### PR DESCRIPTION
Hi there!

The PyPI distributions of this package currently clobber the environment namespace with a top-level `test` package. With this PR, I suggest fixing this.

I stumbled upon this when trying to add your (fantastic!) package to the conda-forge packaging ecosystem: https://github.com/conda-forge/staged-recipes/pull/28067.