### PR TITLE
support live theme changes for searchbox color

### DIFF
--- a/.github/actions/setup_backend/action.yml
+++ b/.github/actions/setup_backend/action.yml
@@ -15,10 +15,6 @@ runs:
   using: composite
   steps:
 
-  - name: Install linux dependencies
-    run: apt-get install zlib1g-dev
-    shell: bash --login -eo pipefail {0}
-
   - name: Set up Python ${{ inputs.python-version }}
     uses: actions/setup-python@v5
     with:

--- a/.github/actions/setup_backend/action.yml
+++ b/.github/actions/setup_backend/action.yml
@@ -15,6 +15,10 @@ runs:
   using: composite
   steps:
 
+  - name: Install linux dependencies
+    run: apt-get install zlib1g-dev
+    shell: bash --login -eo pipefail {0}
+
   - name: Set up Python ${{ inputs.python-version }}
     uses: actions/setup-python@v5
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.11", "3.12"]
@@ -19,7 +19,7 @@ jobs:
 
   types:
     needs: [pre-commit]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.11", "3.12"]
@@ -34,7 +34,7 @@ jobs:
 
   tests:
     needs: [pre-commit, types]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.12"]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
     lint:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
 
       defaults:
         run:

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -40,10 +40,6 @@ class Searchbox extends StreamlitComponentBase<State> {
     inputValue: "",
   };
 
-  private style = new SearchboxStyle(
-    this.props.theme,
-    this.props.args.style_overrides?.searchbox || {},
-  );
   private ref: any = React.createRef();
 
   constructor(props: any) {
@@ -57,6 +53,13 @@ class Searchbox extends StreamlitComponentBase<State> {
       );
     }
   }
+
+  private getStyleFromTheme = (): SearchboxStyle => {
+    return new SearchboxStyle(
+      this.props.theme,
+      this.props.args.style_overrides?.searchbox || {},
+    );
+  };
 
   /**
    * new keystroke on searchbox
@@ -139,13 +142,15 @@ class Searchbox extends StreamlitComponentBase<State> {
       }
     };
 
+    const style = this.getStyleFromTheme();
+
     // option when the clear button is shown
     const clearable = this.props.args.style_overrides?.clear?.clearable;
 
     return (
       <div style={this.props.args.style_overrides?.wrapper || {}}>
         {this.props.args.label && (
-          <div style={this.style.label}>{this.props.args.label}</div>
+          <div style={style.label}>{this.props.args.label}</div>
         )}
 
         <Select
@@ -166,25 +171,25 @@ class Searchbox extends StreamlitComponentBase<State> {
           inputValue={editableAfterSubmit ? this.state.inputValue : undefined}
           isClearable={clearable !== "never"}
           isSearchable={true}
-          styles={this.style.select}
+          styles={style.select}
           options={this.props.args.options}
           placeholder={this.props.args.placeholder}
           // component overrides
           components={{
             ClearIndicator: (props) =>
-              this.style.clearIndicator(
+              style.clearIndicator(
                 props,
                 this.props.args.style_overrides?.clear || {},
               ),
             DropdownIndicator: () =>
-              this.style.iconDropdown(
+              style.iconDropdown(
                 this.state.menu,
                 this.props.args.style_overrides?.dropdown || {},
               ),
             IndicatorSeparator: () => null,
             Input: editableAfterSubmit ? Input : components.Input,
             Option: (props) =>
-              this.style.optionHighlighted(
+              style.optionHighlighted(
                 props,
                 this.props.args.style_overrides?.searchbox?.option
                   ?.highlightColor || undefined,


### PR DESCRIPTION
Currently when switching between different themes, the theme color is only checked when we create the object. This always builds a new style so the color information should always be up to date