### PR TITLE
add default_searchterm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ default: any = None
 
 Default return value in case nothing was submitted or the searchbox cleared.
 
+
+```python
+default_searchterm: str = ''
+```
+
+Default searchterm value when the searchbox is initialized.
+
 ```python
 default_use_searchterm: bool = False
 ```

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -127,13 +127,14 @@ def _process_search(
 def _set_defaults(
     key: str,
     default: Any,
+    default_searchterm: str = "",
     default_options: List[Any] | None = None,
 ) -> None:
     st.session_state[key] = {
         # updated after each selection / reset
         "result": default,
         # updated after each search keystroke
-        "search": "",
+        "search": default_searchterm,
         # updated after each search_function run
         "options_js": [],
         # key that is used by react component, use time suffix to reload after clear
@@ -209,6 +210,7 @@ def st_searchbox(
     label: str | None = None,
     default: Any = None,
     *,
+    default_searchterm: str = "",
     default_use_searchterm: bool = False,
     default_options: List[Any] | None = None,
     clear_on_submit: bool = False,
@@ -237,6 +239,8 @@ def st_searchbox(
             Label shown above the searchbox. Defaults to None.
         default (any, optional):
             Return value if nothing is selected so far. Defaults to None.
+        default_searchterm (str, optional):
+            Inital searchterm when the searchbox is created. Defaults to "".
         default_use_searchterm (bool, optional):
             Return the current searchterm if nothing was selected. Defaults to False.
         default_options (List[any], optional):
@@ -275,7 +279,12 @@ def st_searchbox(
     """
 
     if key not in st.session_state:
-        _set_defaults(key, default, default_options)
+        _set_defaults(
+            key,
+            default,
+            default_searchterm,
+            default_options,
+        )
 
     # everything here is passed to react as this.props.args
     react_state = _get_react_component(
@@ -286,6 +295,7 @@ def st_searchbox(
         edit_after_submit=edit_after_submit,
         style_overrides=style_overrides,
         debounce=debounce,
+        default_searchterm=default_searchterm,
         # react return state within streamlit session_state
         key=st.session_state[key]["key_react"],
     )
@@ -337,13 +347,23 @@ def st_searchbox(
                 submit_function(submit_value)
 
         if clear_on_submit:
-            _set_defaults(key, st.session_state[key]["result"], default_options)
+            _set_defaults(
+                key,
+                st.session_state[key]["result"],
+                default_searchterm,
+                default_options,
+            )
             _rerun(rerun_scope)
 
         return st.session_state[key]["result"]
 
     if interaction == "reset":
-        _set_defaults(key, default, default_options)
+        _set_defaults(
+            key,
+            default,
+            default_searchterm,
+            default_options,
+        )
 
         if reset_function is not None:
             reset_function()

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -37,7 +37,7 @@ class Searchbox extends StreamlitComponentBase<State> {
   public state: State = {
     menu: false,
     option: null,
-    inputValue: "",
+    inputValue: this.props.args.default_searchterm || "",
   };
 
   private ref: any = React.createRef();
@@ -167,8 +167,15 @@ class Searchbox extends StreamlitComponentBase<State> {
                 }
               : this.state.option
           }
-          // value={this.state.option}
-          inputValue={editableAfterSubmit ? this.state.inputValue : undefined}
+          inputValue={
+            // for edit_after_submit we want to disable the tracking
+            // since the inputValue is equal to the value
+            editableAfterSubmit ||
+            // only use this for the initial default value
+            this.props.args.default_searchterm === this.state.inputValue
+              ? this.state.inputValue
+              : undefined
+          }
           isClearable={clearable !== "never"}
           isSearchable={true}
           styles={style.select}


### PR DESCRIPTION
Previously there was no way to set the first searchterm as an editable option (only the placeholder). This adds a new option for it, see https://github.com/m-wrzr/streamlit-searchbox/issues/75