### PR TITLE
fix debouncing / inputValue interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If the rerun should affect the whole app or just the fragment.
 debounce: int = 0
 ```
 
-Delay executing the callback from the react component by `x` milliseconds to avoid too many / redudant requests, i.e. during fast typing.
+Delay executing the callback from the react component by `x` milliseconds to avoid too many / redudant requests, i.e. during fast typing. `NOTE:` this is only applied if `edit_after_submit='disabled'`.
 
 ```python
 min_execution_time: int = 0

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -46,7 +46,11 @@ class Searchbox extends StreamlitComponentBase<State> {
     super(props);
 
     // bind the search function and debounce to avoid too many requests
-    if (props.args.debounce && props.args.debounce > 0) {
+    if (
+      props.args.debounce &&
+      props.args.debounce > 0 &&
+      !this.isInputTrackingActive()
+    ) {
       this.callbackSearch = debounce(
         this.callbackSearch.bind(this),
         props.args.debounce,
@@ -59,6 +63,10 @@ class Searchbox extends StreamlitComponentBase<State> {
       this.props.theme,
       this.props.args.style_overrides?.searchbox || {},
     );
+  };
+
+  private isInputTrackingActive = (): boolean => {
+    return this.props.args.edit_after_submit !== "disabled";
   };
 
   /**
@@ -132,12 +140,9 @@ class Searchbox extends StreamlitComponentBase<State> {
    * @returns
    */
   public render = (): ReactNode => {
-    const editableAfterSubmit =
-      this.props.args.edit_after_submit !== "disabled";
-
     // always focus the input field to enable edits
     const onFocus = () => {
-      if (editableAfterSubmit && this.state.inputValue) {
+      if (this.isInputTrackingActive() && this.state.inputValue) {
         this.state.inputValue && this.ref.current.select.inputRef.select();
       }
     };
@@ -170,7 +175,7 @@ class Searchbox extends StreamlitComponentBase<State> {
           inputValue={
             // for edit_after_submit we want to disable the tracking
             // since the inputValue is equal to the value
-            editableAfterSubmit ||
+            this.isInputTrackingActive() ||
             // only use this for the initial default value
             this.props.args.default_searchterm === this.state.inputValue
               ? this.state.inputValue
@@ -194,7 +199,7 @@ class Searchbox extends StreamlitComponentBase<State> {
                 this.props.args.style_overrides?.dropdown || {},
               ),
             IndicatorSeparator: () => null,
-            Input: editableAfterSubmit ? Input : components.Input,
+            Input: this.isInputTrackingActive() ? Input : components.Input,
             Option: (props) =>
               style.optionHighlighted(
                 props,


### PR DESCRIPTION
When something else than the default for `edit_after_submit=disabled` is used, the `inputValue` state needs to be updated live, but can be debounced. This can lead to lost keystrokes.. See https://github.com/m-wrzr/streamlit-searchbox/issues/79