### PR TITLE
v0.1.21 deprecate min_execution_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.20] - 2025-01-XX
+## [0.1.21] - 2025-03-03
 
-- TODO:
+- deprecate `min_execution_time`
+
+## [0.1.20] - 2025-01-02
+
+- support live theme changes for searchbox color
+- added `default_searchterm`
+- fixed an interaction between `debounce` and `inputValue`
 
 ## [0.1.19] - 2024-11-01
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ rerun_scope: Literal["app", "fragment"] = "app",
 If the rerun should affect the whole app or just the fragment.
 
 ```python
-debounce: int = 0
+debounce: int = 150
 ```
 
 Delay executing the callback from the react component by `x` milliseconds to avoid too many / redudant requests, i.e. during fast typing.
@@ -154,7 +154,7 @@ Delay executing the callback from the react component by `x` milliseconds to avo
 min_execution_time: int = 0
 ```
 
-Delay execution after the search function finished to reach a minimum amount of `x` milliseconds. This can be used to avoid fast consecutive reruns, which can cause resets of the component in some streamlit versions `>=1.35`.
+`DEPRECATED` Delay execution after the search function finished to reach a minimum amount of `x` milliseconds. This can be used to avoid fast consecutive reruns, which can cause resets of the component in some streamlit versions `>=1.35` and `<1.39`.
 
 ---
 

--- a/example.py
+++ b/example.py
@@ -107,14 +107,6 @@ boxes = [
         key=f"{search.__name__}_debounce_250ms",
     ),
     dict(
-        search_function=search,
-        default=None,
-        label=f"{search.__name__}_min_execution_time_500ms",
-        clear_on_submit=False,
-        min_execution_time=500,
-        key=f"{search.__name__}_min_execution_time_500ms",
-    ),
-    dict(
         search_function=search_rnd_delay,
         default=None,
         clear_on_submit=False,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit-searchbox",
-    version="0.1.20",
+    version="0.1.21",
     author="m-wrzr",
     description="Autocomplete Searchbox",
     long_description="Streamlit searchbox that dynamically updates "

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -9,6 +9,7 @@ import functools
 import logging
 import os
 import time
+import warnings
 from typing import Any, Callable, List, Literal, TypedDict
 
 import streamlit as st
@@ -24,8 +25,11 @@ except ImportError:
 # default milliseconds for the search function to run, this is used to avoid
 # fast consecutive reruns. possibly remove this in later versions
 # see: https://github.com/streamlit/streamlit/issues/9002
-MIN_EXECUTION_TIME_DEFAULT = 250 if st.__version__ >= "1.35" else 0
-
+# NOTE: DEPRECATED, remove in future versions
+MIN_EXECUTION_TIME_DEFAULT = (
+    250 if st.__version__ >= "1.35" and st.__version__ < "1.39" else 0
+)
+warnings.simplefilter("once", DeprecationWarning)
 
 # point to build directory
 parent_dir = os.path.dirname(os.path.abspath(__file__))
@@ -261,11 +265,12 @@ def st_searchbox(
             version >= 1.37. Defaults to "app".
         debounce (int, optional):
             Time in milliseconds to wait before sending the input to the search function
-            to avoid too many requests, i.e. during fast keystrokes. Defaults to 0.
+            to avoid too many requests, i.e. during fast keystrokes. Defaults to 150.
         min_execution_time (int, optional):
-            Minimal execution time for the search function in milliseconds. This is used
-            to avoid fast consecutive reruns, where fast reruns can lead to resets
-            within the component in some streamlit versions. Defaults to 0.
+            Deprecated: Minimal execution time for the search function in milliseconds.
+            This is used to avoid fast consecutive reruns, where fast reruns can lead to
+            resets within the component in some streamlit versions.
+            Defaults to 0 or 250 depending on the streamlit version.
         reset_function (Callable[[], None], optional):
             Function that is called after the user reset the combobox. Defaults to None.
         submit_function (Callable[[any], None], optional):
@@ -277,6 +282,13 @@ def st_searchbox(
     Returns:
         any: based on user selection
     """
+
+    if min_execution_time > 0 and min_execution_time != MIN_EXECUTION_TIME_DEFAULT:
+        warnings.warn(
+            "min_execution_time is deprecated and will be removed in the future.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
 
     if key not in st.session_state:
         _set_defaults(

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -5,7 +5,6 @@ module for streamlit searchbox component
 from __future__ import annotations
 
 import datetime
-import functools
 import logging
 import os
 import time
@@ -29,7 +28,6 @@ except ImportError:
 MIN_EXECUTION_TIME_DEFAULT = (
     250 if st.__version__ >= "1.35" and st.__version__ < "1.39" else 0
 )
-warnings.simplefilter("once", DeprecationWarning)
 
 # point to build directory
 parent_dir = os.path.dirname(os.path.abspath(__file__))
@@ -40,26 +38,6 @@ _get_react_component = components.declare_component(
 )
 
 logger = logging.getLogger(__name__)
-
-
-def wrap_inactive_session(func):
-    """
-    session state isn't available anymore due to rerun (as state key can't be empty)
-    if the proxy is missing, this thread isn't really active and an early return is noop
-    """
-
-    @functools.wraps(func)
-    def inner_function(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except KeyError as error:
-            if kwargs.get("key", None) == error.args[0]:
-                logger.debug(f"Session Proxy unavailable for key: {error.args[0]}")
-                return
-
-            raise error
-
-    return inner_function
 
 
 def _rerun(rerun_scope: Literal["app", "fragment"]) -> None:
@@ -207,7 +185,6 @@ class StyleOverrides(TypedDict, total=False):
     searchbox: SearchboxStyle | None
 
 
-@wrap_inactive_session
 def st_searchbox(
     search_function: Callable[[str], List[Any]],
     placeholder: str = "Search ...",

--- a/streamlit_searchbox/frontend/package-lock.json
+++ b/streamlit_searchbox/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "streamlit_searchbox",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "streamlit_searchbox",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "react": "^16.13.1",
         "react-dom": "^16.13.1",

--- a/streamlit_searchbox/frontend/package.json
+++ b/streamlit_searchbox/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit_searchbox",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "dependencies": {
     "react": "^16.13.1",


### PR DESCRIPTION
min_execution_time no longer required for streamlit versions `>=1.39`