### PR TITLE
v0.1.22 help tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ label: str = None
 
 Label shown above the component.
 
+```python
+help: str = None
+```
+
+Shows a help icon with a popover. Only shown when the label is visible.
+
 ---
 
 ### Defaults

--- a/example.py
+++ b/example.py
@@ -219,6 +219,15 @@ boxes = [
             },
         },
     ),
+    dict(
+        search_function=search_wikipedia_ids,
+        placeholder="Search Wikipedia",
+        label="search with help text",
+        default="SOME DEFAULT",
+        help="help text",
+        clear_on_submit=False,
+        key=f"{search.__name__}_help_icon",
+    ),
 ]
 
 

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -205,7 +205,7 @@ def st_searchbox(
     submit_function: Callable[[Any], None] | None = None,
     key: str = "searchbox",
     rerun_scope: Literal["app", "fragment"] = "app",
-    help: str = None,
+    help: str | None = None,
     **kwargs,
 ) -> Any:
     """
@@ -254,6 +254,8 @@ def st_searchbox(
         submit_function (Callable[[any], None], optional):
             Function that is called after the user submits a new/unique option from the
             combobox. Defaults to None.
+        help (str, optional):
+            Show a help tooltip, only visible if a label is provided. Defaults to None.
         key (str, optional):
             Streamlit session key. Defaults to "searchbox".
 

--- a/streamlit_searchbox/__init__.py
+++ b/streamlit_searchbox/__init__.py
@@ -205,6 +205,7 @@ def st_searchbox(
     submit_function: Callable[[Any], None] | None = None,
     key: str = "searchbox",
     rerun_scope: Literal["app", "fragment"] = "app",
+    help: str = None,
     **kwargs,
 ) -> Any:
     """
@@ -286,6 +287,7 @@ def st_searchbox(
         debounce=debounce,
         default_searchterm=default_searchterm,
         # react return state within streamlit session_state
+        help=help,
         key=st.session_state[key]["key_react"],
     )
 

--- a/streamlit_searchbox/frontend/package.json
+++ b/streamlit_searchbox/frontend/package.json
@@ -3,20 +3,22 @@
   "version": "0.1.21",
   "private": true,
   "dependencies": {
+    "baseui": "^12.2.0",
+    "lodash": "^4.17.21",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-feather": "^2.0.10",
     "react-select": "^5.8.0",
-    "streamlit-component-lib": "^2.0.0",
-    "lodash": "^4.17.21"
+    "streamlit-component-lib": "^2.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.150",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "prettier": "^3.2.5",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.2.0",
-    "prettier": "^3.2.5"
+    "typescript": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/streamlit_searchbox/frontend/package.json
+++ b/streamlit_searchbox/frontend/package.json
@@ -9,7 +9,8 @@
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.10",
     "react-select": "^5.8.0",
-    "streamlit-component-lib": "^2.0.0"
+    "streamlit-component-lib": "^2.0.0",
+    "styletron-engine-atomic": "^1.5.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.150",

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -155,9 +155,17 @@ class Searchbox extends StreamlitComponentBase<State> {
     const clearable = this.props.args.style_overrides?.clear?.clearable;
 
     return (
+      // HTH:
       <div style={this.props.args.style_overrides?.wrapper || {}}>
         {this.props.args.label && (
-          <div style={style.label}>{this.props.args.label}</div>
+          <div style={style.label}>{this.props.args.label}
+           {this.props.args.help && (
+	     style.iconHelp(
+               this.props.args.help,
+               this.props.args.style_overrides?.help
+             )
+           )}
+          </div>
         )}
 
         <Select

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -155,7 +155,6 @@ class Searchbox extends StreamlitComponentBase<State> {
     const clearable = this.props.args.style_overrides?.clear?.clearable;
 
     return (
-      // HTH:
       <div style={this.props.args.style_overrides?.wrapper || {}}>
         {this.props.args.label && (
           <div style={style.label}>{this.props.args.label}

--- a/streamlit_searchbox/frontend/src/index.tsx
+++ b/streamlit_searchbox/frontend/src/index.tsx
@@ -2,9 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Searchbox from "./Searchbox";
 
+import { Provider as StyletronProvider } from "styletron-react";
+import { Client as Styletron } from "styletron-engine-atomic";
+
+const engine = new Styletron();
+
 ReactDOM.render(
-  <React.StrictMode>
-    <Searchbox />
-  </React.StrictMode>,
+  <StyletronProvider value={engine}>
+    <React.StrictMode>
+      <Searchbox />
+    </React.StrictMode>
+  </StyletronProvider>,
   document.getElementById("root"),
 );

--- a/streamlit_searchbox/frontend/src/styling.tsx
+++ b/streamlit_searchbox/frontend/src/styling.tsx
@@ -121,6 +121,13 @@ class SearchboxStyle {
       <span style={{
         float: "right"
       }}>
+        <div
+          style={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
         <StatefulTooltip
           content={<div
                      style={{
@@ -161,7 +168,7 @@ class SearchboxStyle {
             },
             Inner: {
               style: {
-                backgroundColor: this.theme.backgroundColor,
+                backgroundColor: this.theme.secondaryBackgroundColor,
                 color: this.theme.textColor,
                 fontSize: "0.82em",
                 fontWeight: "400",
@@ -176,15 +183,14 @@ class SearchboxStyle {
             },
           }} 
         > 
-          <HelpCircleIcon 
-            style={{
-              stroke: "rgba(49, 51, 63, 0.6)",
-              strokeWidth: "2.25",
-              width: "16px",
-              height: "16px",
-            }}
-	  />
+	  <HelpCircleIcon
+            size={16}
+            stroke={this.theme.fadedText60}
+            strokeWidth={2.25}
+            {...overrides}
+          />
         </StatefulTooltip>
+        </div>
       </span>
     )
   }

--- a/streamlit_searchbox/frontend/src/styling.tsx
+++ b/streamlit_searchbox/frontend/src/styling.tsx
@@ -6,6 +6,10 @@ import {
   OptionProps,
   components,
 } from "react-select";
+import { HelpCircle as HelpCircleIcon } from "react-feather"
+import {
+  StatefulTooltip,
+} from "baseui/tooltip"
 
 import {
   DropdownIcon,
@@ -105,6 +109,84 @@ class SearchboxStyle {
         };
       },
     };
+  }
+
+  /**
+   * Help icon and tooltip
+   * @param menu
+   * @returns
+   */
+  iconHelp(help: string, overrides: any) {
+    return (
+      <span style={{
+        float: "right"
+      }}>
+        <StatefulTooltip
+          content={<div
+                     style={{
+                       boxSizing: "border-box",
+                       font: this.theme.font,
+                       fontFamily: "Source Sans Pro, sans-serif",
+                       fontSize: "0.82em",
+                       overflow: "auto",
+                       padding: "1em",
+                     }}
+                   >
+                   {help}
+                   </div>
+          }
+          placement={"auto"}
+          showArrow={false}
+          popoverMargin={10}
+          onMouseEnterDelay={1}
+          overrides={{
+            Body: {
+              style: {
+                // This is annoying, but a bunch of warnings get logged when the
+                // shorthand version `borderRadius` is used here since the long
+                // names are used by BaseWeb and mixing the two is apparently
+                // bad :(
+                borderTopLeftRadius: "100px",
+                borderTopRightRadius: "100px",
+                borderBottomLeftRadius: "100px",
+                borderBottomRightRadius: "100px",
+
+                paddingTop: "0 !important",
+                paddingBottom: "0 !important",
+                paddingLeft: "0 !important",
+                paddingRight: "0 !important",
+
+                backgroundColor: "transparent",
+              },
+            },
+            Inner: {
+              style: {
+                backgroundColor: this.theme.backgroundColor,
+                color: this.theme.textColor,
+                fontSize: "0.82em",
+                fontWeight: "400",
+
+                // See the long comment about `borderRadius`. The same applies here
+                // to `padding`.
+                paddingTop: "0 !important",
+                paddingBottom: "0 !important",
+                paddingLeft: "0 !important",
+                paddingRight: "0 !important",
+              },
+            },
+          }} 
+        > 
+          <HelpCircleIcon 
+            style={{
+              stroke: "rgba(49, 51, 63, 0.6)",
+              strokeWidth: "2.25",
+              width: "16px",
+              height: "16px",
+            }}
+	  />
+        </StatefulTooltip>
+      </span>
+    )
   }
 
   /**


### PR DESCRIPTION
Closes #89 

Still playing around with this one. The help icon and tooltip are a recreation of the streamlit native element. I pilfered the streamlit source code to make it as similar as possible. I am not a fluent React developer, so there may be some faux-pas in the code. 

The positioning of the Tooltip is different from native streamlit elements and I don't know how to fix that (yet). 