### PR TITLE
v0.1.24 fix edit_after_submit focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ README.local.md
 venv*
 tests/screenshots/*.png
 tests_local
+icon.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.24] - 2025-12-23
+
+- fix `edit_after_submit` not being focusable after selection for modes other than `disabled`
+
 ## [0.1.23] - 2025-08-10
 
 - add `optionEmpty` parameter to `style_overrides/searchbox` to hide the "No Options" popup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "streamlit-searchbox"
-version = "0.1.23rc5"
+version = "0.1.24rc0"
 description = "Autocomplete Searchbox that dynamically updates suggestions based on a provided function."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   # version >1.37 reruns can lead to constant iFrame resets
   # version 1.35/1.36 also have reset issues but less frequent
+  # TODO: increase required version to what is used in the tests, e.g. 25?
   "streamlit >= 1.0",
 ]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "streamlit-searchbox"
-version = "0.1.24rc0"
+version = "0.1.24"
 description = "Autocomplete Searchbox that dynamically updates suggestions based on a provided function."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/streamlit_searchbox/frontend/src/Searchbox.tsx
+++ b/streamlit_searchbox/frontend/src/Searchbox.tsx
@@ -40,8 +40,6 @@ class Searchbox extends StreamlitComponentBase<State> {
     inputValue: this.props.args.default_searchterm || "",
   };
 
-  private ref: any = React.createRef();
-
   constructor(props: any) {
     super(props);
 
@@ -142,13 +140,6 @@ class Searchbox extends StreamlitComponentBase<State> {
    * @returns
    */
   public render = (): ReactNode => {
-    // always focus the input field to enable edits
-    const onFocus = () => {
-      if (this.isInputTrackingActive() && this.state.inputValue) {
-        this.state.inputValue && this.ref.current.select.inputRef.select();
-      }
-    };
-
     const style = this.getStyleFromTheme();
 
     // option when the clear button is shown
@@ -223,7 +214,6 @@ class Searchbox extends StreamlitComponentBase<State> {
           }}
           // handlers
           filterOption={(_, __) => true}
-          onFocus={() => onFocus()}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           onChange={(option: any, a: any) => {
             switch (a.action) {

--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 
 [[package]]
 name = "streamlit-searchbox"
-version = "0.1.24rc0"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "streamlit" },

--- a/uv.lock
+++ b/uv.lock
@@ -1332,7 +1332,7 @@ wheels = [
 
 [[package]]
 name = "streamlit-searchbox"
-version = "0.1.23rc5"
+version = "0.1.24rc0"
 source = { editable = "." }
 dependencies = [
     { name = "streamlit" },


### PR DESCRIPTION
See issue https://github.com/m-wrzr/streamlit-searchbox/issues/100 - looks like the `onFocus` was left over from a previous version and reference not existing

<img width="508" height="121" alt="Bildschirmfoto 2025-12-23 um 08 39 44" src="https://github.com/user-attachments/assets/ec242bfa-ecc7-4103-935a-52cb61063347" />
